### PR TITLE
Fix ClassCastException

### DIFF
--- a/src/org/kohsuke/stapler/idea/JellyLanguageInjector.java
+++ b/src/org/kohsuke/stapler/idea/JellyLanguageInjector.java
@@ -31,6 +31,9 @@ public class JellyLanguageInjector implements MultiHostInjector {
         if (context instanceof XmlAttributeValue) {
             final XmlAttributeValue value = (XmlAttributeValue)context;
 
+            if (!(value.getParent() instanceof XmlAttribute))
+                return; // not an XML attribute, probably an XML PI
+
             XmlAttribute a = (XmlAttribute) value.getParent();
             if(!a.getName().equals("style"))
                 return; // not a style attribute
@@ -43,6 +46,7 @@ public class JellyLanguageInjector implements MultiHostInjector {
                     (PsiLanguageInjectionHost)value,
                     TextRange.from(1, value.getTextLength() - 2));
             registrar.doneInjecting();
+            return;
         }
         
         // inject JavaScript to <script>


### PR DESCRIPTION
com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectInformationWithProgress(LineMarkersPass.java:118)
    at com.intellij.codeInsight.daemon.impl.ProgressableTextEditorHighlightingPass.doCollectInformation(ProgressableTextEditorHighlightingPass.java:58)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)

java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.SlowLineMarkersPass.doCollectInformation(SlowLineMarkersPass.java:66)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)

java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectInformationWithProgress(LineMarkersPass.java:118)
    at com.intellij.codeInsight.daemon.impl.ProgressableTextEditorHighlightingPass.doCollectInformation(ProgressableTextEditorHighlightingPass.java:58)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)

java.util.concurrent.ExecutionException: java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at java.util.concurrent.FutureTask$Sync.innerGet(FutureTask.java:222)
    at java.util.concurrent.FutureTask.get(FutureTask.java:83)
    at com.intellij.concurrency.PrioritizedFutureTask.access$301(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:77)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)
Caused by: java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectInformationWithProgress(LineMarkersPass.java:118)
    at com.intellij.codeInsight.daemon.impl.ProgressableTextEditorHighlightingPass.doCollectInformation(ProgressableTextEditorHighlightingPass.java:58)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    ... 4 more

java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectInformationWithProgress(LineMarkersPass.java:118)
    at com.intellij.codeInsight.daemon.impl.ProgressableTextEditorHighlightingPass.doCollectInformation(ProgressableTextEditorHighlightingPass.java:58)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)

java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.SlowLineMarkersPass.doCollectInformation(SlowLineMarkersPass.java:66)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)

java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.SlowLineMarkersPass.doCollectInformation(SlowLineMarkersPass.java:66)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)

java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.SlowLineMarkersPass.doCollectInformation(SlowLineMarkersPass.java:66)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)

java.util.concurrent.ExecutionException: java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at java.util.concurrent.FutureTask$Sync.innerGet(FutureTask.java:222)
    at java.util.concurrent.FutureTask.get(FutureTask.java:83)
    at com.intellij.concurrency.PrioritizedFutureTask.access$301(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:77)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)
Caused by: java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.SlowLineMarkersPass.doCollectInformation(SlowLineMarkersPass.java:66)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    ... 4 more

java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.SlowLineMarkersPass.doCollectInformation(SlowLineMarkersPass.java:66)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)

java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.SlowLineMarkersPass.doCollectInformation(SlowLineMarkersPass.java:66)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)

java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.SlowLineMarkersPass.doCollectInformation(SlowLineMarkersPass.java:66)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)

java.util.concurrent.ExecutionException: java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at java.util.concurrent.FutureTask$Sync.innerGet(FutureTask.java:222)
    at java.util.concurrent.FutureTask.get(FutureTask.java:83)
    at com.intellij.concurrency.PrioritizedFutureTask.access$301(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:77)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)
Caused by: java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.SlowLineMarkersPass.doCollectInformation(SlowLineMarkersPass.java:66)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    ... 4 more

java.lang.ClassCastException: com.intellij.psi.impl.source.xml.XmlProcessingInstructionImpl cannot be cast to com.intellij.psi.xml.XmlAttribute
    at org.kohsuke.stapler.idea.JellyLanguageInjector.getLanguagesToInject(JellyLanguageInjector.java:34)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider$MyInjProcessor.process(InjectedPsiCachedValueProvider.java:81)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:432)
    at com.intellij.psi.impl.source.tree.injected.InjectedPsiCachedValueProvider.doCompute(InjectedPsiCachedValueProvider.java:61)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.a(InjectedLanguageUtil.java:225)
    at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil.enumerate(InjectedLanguageUtil.java:143)
    at com.intellij.codeInsight.daemon.impl.LineMarkersPass.collectLineMarkersForInjected(LineMarkersPass.java:206)
    at com.intellij.codeInsight.daemon.impl.SlowLineMarkersPass.doCollectInformation(SlowLineMarkersPass.java:66)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:61)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:350)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1049)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:342)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:218)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:340)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:316)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:134)
    at com.intellij.concurrency.JobUtil$3.call(JobUtil.java:131)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at com.intellij.concurrency.PrioritizedFutureTask.access$101(PrioritizedFutureTask.java:31)
    at com.intellij.concurrency.PrioritizedFutureTask$1.run(PrioritizedFutureTask.java:70)
    at com.intellij.concurrency.PrioritizedFutureTask.run(PrioritizedFutureTask.java:113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)
