### PR TITLE
resolved jelly namespace URIs to embedded XSDs to support syntax completion

### DIFF
--- a/src/org/kohsuke/stapler/idea/StaplerApplicationComponent.java
+++ b/src/org/kohsuke/stapler/idea/StaplerApplicationComponent.java
@@ -9,19 +9,19 @@ import com.intellij.lang.xml.XMLLanguage;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ApplicationComponent;
 import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.filters.AndFilter;
 import com.intellij.psi.filters.ClassFilter;
 import com.intellij.psi.filters.position.NamespaceFilter;
 import com.intellij.psi.meta.MetaDataRegistrar;
 import com.intellij.psi.xml.XmlDocument;
+import com.intellij.util.io.URLUtil;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.kohsuke.stapler.idea.descriptor.XmlNSDescriptorImpl;
 
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 
 /**
@@ -55,39 +55,26 @@ public class StaplerApplicationComponent implements ApplicationComponent, Inspec
 
                         { // Mangle Resource URL to match what IntelliJ expects for the location argument
                             String extForm = res.toExternalForm();
-                            String jarSuffix = "";
 
-                            { // Strip jar: prefix and !-suffix before fixing embedded file: url
-                                if (extForm.startsWith("jar:")) {
-                                    int bangIndex = extForm.indexOf('!');
-                                    if (bangIndex >= 0) {
-                                        jarSuffix = extForm.substring(bangIndex);
-                                        extForm = extForm.substring("jar:".length(), bangIndex);
-                                    } else {
-                                        extForm = extForm.substring("jar:".length());
-                                    }
-                                }
+                            // the intention was to call URLUtil directly, but there appears to be some build
+                            // incompatibility that is simply easier to work around by copying the method source into
+                            // this class
+                            Pair<String, String> pair = splitJarUrl(extForm);
+                            if (pair != null) {
+
+                                // This procedure is necessary for complete support for this resource in the
+                                // {@link MapExternalResourceDialog}, but is not necessary for Jelly namespace resolution
+                                // in the editor
+                                extForm = pair.first + URLUtil.JAR_SEPARATOR + pair.second;
+                            } else {
+                                // the scheme separator appears to be minimally necessary for the Jelly URLResolver to
+                                // identify this as a proper file: url.
+                                extForm = extForm.replaceAll("file:", "file://");
                             }
 
-                            { // convert file: URL to path, per
-                              // https://weblogs.java.net/blog/kohsuke/archive/2007/04/how_to_convert.html
-                                if (extForm.startsWith("file:")) {
-                                    try {
-                                        extForm = new File(new URI(extForm)).getPath();
-                                    } catch (URISyntaxException e) {
-                                        try {
-                                            extForm = new File(new URL(extForm).getPath()).getPath();
-                                        } catch (MalformedURLException l) {
-                                            extForm = extForm.substring("file:".length());
-                                        }
-                                    }
-
-                                }
-                            }
-                            
                             erm.addResource(
                                     "jelly:"+s,  // namespace URI
-                                    extForm + jarSuffix); // re-append !-suffix
+                                    URLUtil.unescapePercentSequences(extForm)); // xmlns checking fails without this call
                         }
                     }
                 }
@@ -126,4 +113,38 @@ public class StaplerApplicationComponent implements ApplicationComponent, Inspec
 
     public static final String DUMMY_SCHEMA_URL = "dummy-schema-url";
 
+    /**
+     * Splits .jar URL along a separator and strips "jar" and "file" prefixes if any.
+     * Returns a pair of path to a .jar file and entry name inside a .jar, or null if the URL does not contain a separator.
+     *
+     * Copied verbatim from {@link URLUtil#splitJarUrl(String)} from source, because when called from URLUtil, it
+     * always returns null, even if the JAR_SEPARATOR is clearly present in the URL. I imagine this is due to the source
+     * being more recent than the built library.
+     *
+     * E.g. "jar:file:///path/to/jar.jar!/resource.xml" is converted into ["/path/to/jar.jar", "resource.xml"].
+     */
+    @Nullable
+    public static Pair<String, String> splitJarUrl(@NotNull String url) {
+        int pivot = url.indexOf(URLUtil.JAR_SEPARATOR);
+        if (pivot < 0) return null;
+
+        String resourcePath = url.substring(pivot + 2);
+        String jarPath = url.substring(0, pivot);
+
+        if (StringUtil.startsWithConcatenation(jarPath, URLUtil.JAR_PROTOCOL, ":")) {
+            jarPath = jarPath.substring(URLUtil.JAR_PROTOCOL.length() + 1);
+        }
+
+        if (jarPath.startsWith(URLUtil.FILE_PROTOCOL)) {
+            jarPath = jarPath.substring(URLUtil.FILE_PROTOCOL.length());
+            if (jarPath.startsWith(URLUtil.SCHEME_SEPARATOR)) {
+                jarPath = jarPath.substring(URLUtil.SCHEME_SEPARATOR.length());
+            }
+            else if (StringUtil.startsWithChar(jarPath, ':')) {
+                jarPath = jarPath.substring(1);
+            }
+        }
+
+        return Pair.create(jarPath, resourcePath);
+    }
 }


### PR DESCRIPTION
The error-marked jelly namespace URI's and code completion issue is caused by Intellij not handling jar: URL schemes in its ExternalResourceManager. My solution was to mangle the URL external form to strip the jar: and file: prefixes and un-escape the file path part (which contains %20s when executed on a Mac) in a platform-independent way by following the procedure described here:

https://weblogs.java.net/blog/kohsuke/archive/2007/04/how_to_convert.html
