### PR TITLE
Fix NPE

### DIFF
--- a/src/org/kohsuke/stapler/idea/descriptor/XmlElementDescriptorImpl.java
+++ b/src/org/kohsuke/stapler/idea/descriptor/XmlElementDescriptorImpl.java
@@ -51,8 +51,7 @@ public class XmlElementDescriptorImpl extends BaseXmlElementDescriptorImpl {
                 
                 PsiFile f = child.getContainingFile();
                 XmlNSDescriptor nsd = ((XmlFile)f).getDocument().getDefaultNSDescriptor(child.getNamespace(), false);
-                XmlElementDescriptor d = nsd.getElementDescriptor(child);
-                return d;
+                return (nsd == null) ? null : nsd.getElementDescriptor(child);
             }
 
         } else


### PR DESCRIPTION
Fix a NPE when viewing jelly file:

```
null
java.lang.NullPointerException
    at org.kohsuke.stapler.idea.descriptor.XmlElementDescriptorImpl.getElementDescriptor(XmlElementDescriptorImpl.java:54)
    at com.intellij.xml.XmlExtension.getElementDescriptor(XmlExtension.java:133)
    at com.intellij.xml.util.XmlUtil.getDescriptorFromContext(XmlUtil.java:563)
    at com.intellij.codeInsight.daemon.impl.analysis.XmlHighlightVisitor.c(XmlHighlightVisitor.java:256)
    at com.intellij.codeInsight.daemon.impl.analysis.XmlHighlightVisitor.b(XmlHighlightVisitor.java:167)
    at com.intellij.codeInsight.daemon.impl.analysis.XmlHighlightVisitor.visitXmlToken(XmlHighlightVisitor.java:131)
    at com.intellij.psi.impl.source.xml.XmlTokenImpl.accept(XmlTokenImpl.java:46)
    at com.intellij.codeInsight.daemon.impl.analysis.XmlHighlightVisitor.visit(XmlHighlightVisitor.java:740)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:351)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.access$100(GeneralHighlightingPass.java:62)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass$3.run(GeneralHighlightingPass.java:280)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:305)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.access$200(GeneralHighlightingPass.java:62)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass$4.run(GeneralHighlightingPass.java:311)
    at com.intellij.codeInsight.daemon.impl.analysis.XmlHighlightVisitor.analyze(XmlHighlightVisitor.java:750)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:308)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.access$200(GeneralHighlightingPass.java:62)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass$4.run(GeneralHighlightingPass.java:311)
    at com.intellij.codeInsight.daemon.impl.DefaultHighlightVisitor.analyze(DefaultHighlightVisitor.java:83)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:308)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.a(GeneralHighlightingPass.java:277)
    at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.collectInformationWithProgress(GeneralHighlightingPass.java:216)
    at com.intellij.codeInsight.daemon.impl.ProgressableTextEditorHighlightingPass.doCollectInformation(ProgressableTextEditorHighlightingPass.java:82)
    at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:70)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1$1.run(PassExecutorService.java:444)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1178)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass$1.run(PassExecutorService.java:435)
    at com.intellij.openapi.progress.impl.CoreProgressManager.a(CoreProgressManager.java:446)
    at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:392)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:54)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:432)
    at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:408)
    at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:206)
    at jsr166e.ForkJoinTask.doExec(ForkJoinTask.java:260)
    at jsr166e.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:858)
    at jsr166e.ForkJoinPool.scan(ForkJoinPool.java:1687)
    at jsr166e.ForkJoinPool.runWorker(ForkJoinPool.java:1642)
    at jsr166e.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:108)
```
