### PR TITLE
Enable the Release Drafter based on jenkinsci documentation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,58 +1,16 @@
 # Configuration for Release Drafter: https://github.com/marketplace/actions/release-drafter
 # Adopted from the https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
-# Older tags pretty much follow SemVer so not modifying the version-template
-
+_extends: jenkinsci/.github
+# Older tags pretty much follow SemVer so reverting the version-template
+version-template: '$MAJOR.$MINOR.$PATCH'
+# let us use the version resolver
 name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
-# Emoji reference: https://gitmoji.carloscuesta.me/
-categories:
-  - title: ":boom: Breaking changes"
-    labels: 
-      - breaking
-  - title: 🚨 Removed
-    label: removed
-  - title: ":tada: Major features and improvements"
-    labels:
-      - major-enhancement
-      - major-rfe
-  - title: 🐛 Major bug fixes
-    labels:
-      - major-bug
-  - title: ⚠️ Deprecated
-    label: deprecated
-  - title: 🚀 New features and improvements
-    labels:
-      - enhancement
-      - feature
-      - rfe
-  - title: 🐛 Bug Fixes
-    labels:
-      - bug
-      - fix
-      - bugfix
-      - regression
-  # Default label used by Dependabot
-  - title: 📦 Dependency updates
-    label: dependencies
-  - title: 📝 Documentation updates
-    label: documentation
-  - title: 👻 Maintenance
-    labels: 
-      - chore
-      - internal
-  - title: 🚦 Tests
-    labels: 
-      - test
-      - tests
-exclude-labels:
-  - reverted
-  - no-changelog
-  - skip-changelog
-  - invalid
 version-resolver:
   major:
     labels:
       - 'major'
+      - 'breaking'
   minor:
     labels:
       - 'minor'
@@ -60,6 +18,3 @@ version-resolver:
     labels:
       - 'patch'
   default: patch
-template: |
-  <!-- Optional: add a release summary here -->
-  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,65 @@
+# Configuration for Release Drafter: https://github.com/marketplace/actions/release-drafter
+# Adopted from the https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+# Older tags pretty much follow SemVer so not modifying the version-template
+
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+# Emoji reference: https://gitmoji.carloscuesta.me/
+categories:
+  - title: ":boom: Breaking changes"
+    labels: 
+      - breaking
+  - title: 🚨 Removed
+    label: removed
+  - title: ":tada: Major features and improvements"
+    labels:
+      - major-enhancement
+      - major-rfe
+  - title: 🐛 Major bug fixes
+    labels:
+      - major-bug
+  - title: ⚠️ Deprecated
+    label: deprecated
+  - title: 🚀 New features and improvements
+    labels:
+      - enhancement
+      - feature
+      - rfe
+  - title: 🐛 Bug Fixes
+    labels:
+      - bug
+      - fix
+      - bugfix
+      - regression
+  # Default label used by Dependabot
+  - title: 📦 Dependency updates
+    label: dependencies
+  - title: 📝 Documentation updates
+    label: documentation
+  - title: 👻 Maintenance
+    labels: 
+      - chore
+      - internal
+  - title: 🚦 Tests
+    labels: 
+      - test
+      - tests
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  <!-- Optional: add a release summary here -->
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+# Automates creation of Release Drafts using Release Drafter
+# More Info: https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolve #19 by following the https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc