### PR TITLE
Adopt the IntelliJ Plugin Verifier into the Build and CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,11 +45,14 @@ pipeline {
                                     command = "./" + command
                                 }
                                 infra.runWithJava(command, "8", extraEnv)
-                                if (isUnix()) {
-                                    archiveArtifacts artifacts: '**/build/reports/pluginVerifier/**', fingerprint: false
-                                    // Look for presence of compatibility warnings or problems
-                                    sh "./script/check-plugin-verification.sh"
-                                }
+                            }
+                            archiveArtifacts artifacts: '**/build/reports/pluginVerifier/**', fingerprint: false
+                            // Look for presence of compatibility warnings or problems
+                            sh "./script/check-plugin-verification.sh"
+                        }
+                        when {
+                            expression {
+                                return isUnix()
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,12 @@
+// do no bother launching Gradle Daemon
+def gradleOptions = ['--no-daemon']
+// do not print the Welcome Gradle message. Seems pointless in CI
+gradleOptions += "-Dorg.gradle.internal.launcher.welcomeMessageEnabled=false"
+// more logs for troubleshooting
+gradleOptions += "--info"
+// tell gradle-intellij-plugin not to download sources
+def extraEnv = ["CI=true"]
+
 pipeline {
     agent none
     options {
@@ -20,17 +29,27 @@ pipeline {
                     stage('Build Plugin') {
                         steps {
                             script {
-                                // do no bother launching Gradle Daemon
-                                def gradleOptions = ['--no-daemon']
-                                // do not print the Welcome Gradle message. Seems pointless in CI
-                                gradleOptions += "-Dorg.gradle.internal.launcher.welcomeMessageEnabled=false"
-                                // more logs for troubleshooting
-                                gradleOptions += "--info"
                                 String command = "gradlew ${gradleOptions.join ' '} clean check assemble"
                                 if (isUnix()) {
                                     command = "./" + command
                                 }
-                                infra.runWithJava(command, "8")
+                                infra.runWithJava(command, "8", extraEnv)
+                            }
+                        }
+                    }
+                    stage('Verify Plugin') {
+                        steps {
+                            script {
+                                String command = "gradlew ${gradleOptions.join ' '} verifyPlugin runPluginVerifier"
+                                if (isUnix()) {
+                                    command = "./" + command
+                                }
+                                infra.runWithJava(command, "8", extraEnv)
+                                if (isUnix()) {
+                                    archiveArtifacts artifacts: '**/build/reports/pluginVerifier/**', fingerprint: false
+                                    // Look for presence of compatibility warnings or problems
+                                    sh "./script/check-plugin-verification.sh"
+                                }
                             }
                         }
                     }

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,13 @@ dependencies {
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
+
+// https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+// https://plugins.jetbrains.com/docs/marketplace/product-versions-in-use-statistics.html
+// https://www.jetbrains.com/idea/download/other.html
 intellij {
     version = ideaVersion
-    setPlugins("properties")
+    plugins = ["properties"]
 }
 
 patchPluginXml {
@@ -34,4 +38,11 @@ patchPluginXml {
     changeNotes("""
       Maintenance Release that should be functinaly equivalent to 1.8.<br>
     """)
+}
+
+runPluginVerifier {
+    // Rather arbitrarily chosen first releases of last three year.
+    // Product version in use statistics say last 3 major releases. It does not define "major release" though but
+    // but educated guess is that `year.version` is what is considered major.
+    ideVersions = ["2019.1.4", "2020.1.3", "2021.1"]
 }

--- a/script/check-plugin-verification.sh
+++ b/script/check-plugin-verification.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# https://github.com/JetBrains/intellij-plugin-verifier/blob/v1.254/README.md lists file names to check
+if [ -n "$(find ./build/reports/pluginVerifier -name compatibility-warnings.txt -or -name compatibility-problems.txt)" ]
+then
+  echo "ERROR: Compatibility issue!"
+  exit 1
+fi

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -46,6 +46,13 @@
     </action>
   </actions>
 
+  <!-- https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
+  <!-- The bare platform shared by all jetbrains products -->
+  <depends>com.intellij.modules.platform</depends>
+  <!-- Jelly is an XML file type -->
+  <depends>com.intellij.modules.xml</depends>
+  <!-- Stapler is a Java Framework. And this is required to maintain compatibility past 2019.2 -->
+  <depends>com.intellij.modules.java</depends>
   <!-- needed for defining web facet -->
   <!--depends>com.intellij.javaee</depends-->
   <!-- needed for i18n support -->


### PR DESCRIPTION
Verify against the last three years of the releases.

Also, `CI` env variable is set so that `gradle-intellij-plugin` can skip steps that it thinks are not necessary for CI, e.g. downloading sources.